### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Linux Screenshot
 
 Notes:
 - Windows
-    * Requires .NET 2.0 api compatibility level 
+    * Requires .NET 3.5 or higher api compatibility level 
     * Async dialog opening not implemented, ..Async methods simply calls regular sync methods.
     * Plugin import settings should be like this;
     


### PR DESCRIPTION
Updated the README.md to note the correct required .Net API compatibility level (3.5x fom 2.0) Unity supports 4.0 and requires .NET 4.0 API compatibility in unity 2018.4-2019.4