### PR TITLE
Fix for issue #89

### DIFF
--- a/Assets/StandaloneFileBrowser/StandaloneFileBrowserWindows.cs
+++ b/Assets/StandaloneFileBrowser/StandaloneFileBrowserWindows.cs
@@ -102,7 +102,7 @@ namespace SFB {
         private static string GetFilterFromFileExtensionList(ExtensionFilter[] extensions) {
             var filterString = "";
             foreach (var filter in extensions) {
-                filterString += filter.Name + "(";
+                filterString += filter.Name + " (";
 
                 foreach (var ext in filter.Extensions) {
                     filterString += "*." + ext + ",";


### PR DESCRIPTION
Added missing space before open parenthesis at line 105 of StandaloneFileBrowserWindows.cs. Closes #89 