### PR TITLE
Filebrowser now opens instantly, not after the user clicks on a random point on screen (WebGL)

### DIFF
--- a/Assets/StandaloneFileBrowser/Plugins/StandaloneFileBrowser.jslib
+++ b/Assets/StandaloneFileBrowser/Plugins/StandaloneFileBrowser.jslib
@@ -48,10 +48,7 @@ var StandaloneFileBrowserWebGLPlugin = {
         }
         document.body.appendChild(fileInput);
 
-        document.onmouseup = function() {
-            fileInput.click();
-            document.onmouseup = null;
-        }
+        fileInput.click();
     },
 
     // Save file


### PR DESCRIPTION
Without this fix, on WebGL, the user needs to click on the screen to make the file browser appear. This fix removes the extra click, and opens the file browser right when UploadFile() is called.