### PR TITLE
#102 - exclusive fullscreen fix/workaround

### DIFF
--- a/Assets/StandaloneFileBrowser/StandaloneFileBrowser.cs
+++ b/Assets/StandaloneFileBrowser/StandaloneFileBrowser.cs
@@ -1,4 +1,5 @@
 using System;
+using UnityEngine;
 
 namespace SFB {
     public struct ExtensionFilter {
@@ -35,8 +36,13 @@ namespace SFB {
         /// <param name="multiselect">Allow multiple file selection</param>
         /// <returns>Returns array of chosen paths. Zero length array when cancelled</returns>
         public static string[] OpenFilePanel(string title, string directory, string extension, bool multiselect) {
+            SetWindowedFullscreenIfExclusive();
+            
             var extensions = string.IsNullOrEmpty(extension) ? null : new [] { new ExtensionFilter("", extension) };
-            return OpenFilePanel(title, directory, extensions, multiselect);
+            var res = OpenFilePanel(title, directory, extensions, multiselect);
+
+            SetExclusiveBackIfChanged();
+            return res;
         }
 
         /// <summary>
@@ -48,7 +54,12 @@ namespace SFB {
         /// <param name="multiselect">Allow multiple file selection</param>
         /// <returns>Returns array of chosen paths. Zero length array when cancelled</returns>
         public static string[] OpenFilePanel(string title, string directory, ExtensionFilter[] extensions, bool multiselect) {
-            return _platformWrapper.OpenFilePanel(title, directory, extensions, multiselect);
+            SetWindowedFullscreenIfExclusive();
+            
+            var res = _platformWrapper.OpenFilePanel(title, directory, extensions, multiselect);
+
+            SetExclusiveBackIfChanged();
+            return res;
         }
 
         /// <summary>
@@ -59,7 +70,14 @@ namespace SFB {
         /// <param name="extension">Allowed extension</param>
         /// <param name="multiselect">Allow multiple file selection</param>
         /// <param name="cb">Callback")</param>
-        public static void OpenFilePanelAsync(string title, string directory, string extension, bool multiselect, Action<string[]> cb) {
+        public static void OpenFilePanelAsync(string title, string directory, string extension, bool multiselect, Action<string[]> originalCb) {
+            SetWindowedFullscreenIfExclusive();
+            Action<string[]> cb = (string[] strs) =>
+            {
+                SetExclusiveBackIfChanged();
+                originalCb.Invoke(strs);
+            };
+
             var extensions = string.IsNullOrEmpty(extension) ? null : new [] { new ExtensionFilter("", extension) };
             OpenFilePanelAsync(title, directory, extensions, multiselect, cb);
         }
@@ -72,7 +90,14 @@ namespace SFB {
         /// <param name="extensions">List of extension filters. Filter Example: new ExtensionFilter("Image Files", "jpg", "png")</param>
         /// <param name="multiselect">Allow multiple file selection</param>
         /// <param name="cb">Callback")</param>
-        public static void OpenFilePanelAsync(string title, string directory, ExtensionFilter[] extensions, bool multiselect, Action<string[]> cb) {
+        public static void OpenFilePanelAsync(string title, string directory, ExtensionFilter[] extensions, bool multiselect, Action<string[]> originalCb) {
+            SetWindowedFullscreenIfExclusive();
+            Action<string[]> cb = (string[] strs) =>
+            {
+                SetExclusiveBackIfChanged();
+                originalCb.Invoke(strs);
+            };
+
             _platformWrapper.OpenFilePanelAsync(title, directory, extensions, multiselect, cb);
         }
 
@@ -85,7 +110,12 @@ namespace SFB {
         /// <param name="multiselect"></param>
         /// <returns>Returns array of chosen paths. Zero length array when cancelled</returns>
         public static string[] OpenFolderPanel(string title, string directory, bool multiselect) {
-            return _platformWrapper.OpenFolderPanel(title, directory, multiselect);
+            SetWindowedFullscreenIfExclusive();
+
+            var res = _platformWrapper.OpenFolderPanel(title, directory, multiselect);
+
+            SetExclusiveBackIfChanged();
+            return res;
         }
 
         /// <summary>
@@ -96,7 +126,14 @@ namespace SFB {
         /// <param name="directory">Root directory</param>
         /// <param name="multiselect"></param>
         /// <param name="cb">Callback")</param>
-        public static void OpenFolderPanelAsync(string title, string directory, bool multiselect, Action<string[]> cb) {
+        public static void OpenFolderPanelAsync(string title, string directory, bool multiselect, Action<string[]> originalCb) {
+            SetWindowedFullscreenIfExclusive();
+            Action<string[]> cb = (string[] strs) =>
+            {
+                SetExclusiveBackIfChanged();
+                originalCb.Invoke(strs);
+            };
+
             _platformWrapper.OpenFolderPanelAsync(title, directory, multiselect, cb);
         }
 
@@ -109,8 +146,13 @@ namespace SFB {
         /// <param name="extension">File extension</param>
         /// <returns>Returns chosen path. Empty string when cancelled</returns>
         public static string SaveFilePanel(string title, string directory, string defaultName , string extension) {
+            SetWindowedFullscreenIfExclusive();
+
             var extensions = string.IsNullOrEmpty(extension) ? null : new [] { new ExtensionFilter("", extension) };
-            return SaveFilePanel(title, directory, defaultName, extensions);
+            var res = SaveFilePanel(title, directory, defaultName, extensions);
+
+            SetExclusiveBackIfChanged();
+            return res;
         }
 
         /// <summary>
@@ -122,7 +164,12 @@ namespace SFB {
         /// <param name="extensions">List of extension filters. Filter Example: new ExtensionFilter("Image Files", "jpg", "png")</param>
         /// <returns>Returns chosen path. Empty string when cancelled</returns>
         public static string SaveFilePanel(string title, string directory, string defaultName, ExtensionFilter[] extensions) {
-            return _platformWrapper.SaveFilePanel(title, directory, defaultName, extensions);
+            SetWindowedFullscreenIfExclusive();
+
+            var res = _platformWrapper.SaveFilePanel(title, directory, defaultName, extensions);
+
+            SetExclusiveBackIfChanged();
+            return res;
         }
 
         /// <summary>
@@ -133,7 +180,14 @@ namespace SFB {
         /// <param name="defaultName">Default file name</param>
         /// <param name="extension">File extension</param>
         /// <param name="cb">Callback")</param>
-        public static void SaveFilePanelAsync(string title, string directory, string defaultName , string extension, Action<string> cb) {
+        public static void SaveFilePanelAsync(string title, string directory, string defaultName , string extension, Action<string> originalCb) {
+            SetWindowedFullscreenIfExclusive();
+            Action<string> cb = (string str) =>
+            {
+                SetExclusiveBackIfChanged();
+                originalCb.Invoke(str);
+            };
+
             var extensions = string.IsNullOrEmpty(extension) ? null : new [] { new ExtensionFilter("", extension) };
             SaveFilePanelAsync(title, directory, defaultName, extensions, cb);
         }
@@ -146,8 +200,37 @@ namespace SFB {
         /// <param name="defaultName">Default file name</param>
         /// <param name="extensions">List of extension filters. Filter Example: new ExtensionFilter("Image Files", "jpg", "png")</param>
         /// <param name="cb">Callback")</param>
-        public static void SaveFilePanelAsync(string title, string directory, string defaultName, ExtensionFilter[] extensions, Action<string> cb) {
+        public static void SaveFilePanelAsync(string title, string directory, string defaultName, ExtensionFilter[] extensions, Action<string> originalCb) {
+            SetWindowedFullscreenIfExclusive();
+            Action<string> cb = (string str) =>
+            {
+                SetExclusiveBackIfChanged();
+                originalCb.Invoke(str);
+            };
+
             _platformWrapper.SaveFilePanelAsync(title, directory, defaultName, extensions, cb);
+        }
+
+        private static bool didChangeFullscreenMode = false;
+        private static void SetWindowedFullscreenIfExclusive()
+        {
+            if (Screen.fullScreenMode == FullScreenMode.ExclusiveFullScreen)
+            {
+                Screen.fullScreenMode = FullScreenMode.FullScreenWindow;
+                didChangeFullscreenMode = true;
+            }
+            else
+            {
+                didChangeFullscreenMode = false;
+            }
+        }
+        private static void SetExclusiveBackIfChanged()
+        {
+            if (didChangeFullscreenMode)
+            {
+                Screen.fullScreenMode = FullScreenMode.ExclusiveFullScreen;
+                didChangeFullscreenMode = false;
+            }
         }
     }
 }


### PR DESCRIPTION
A simple workaround for #102.

The Sync functions are untested, but the Async ones work.

I wouldn't really expect this to get merged, but it seems simpler to share the fix as a PR.

The way it saves whether to switch back to exclusive fullscreen is not the most reliable, but it should work as long as only one file browser is used at once, which I imagine is most use cases.

There's probably a better way to "append" callbacks, but I don't know it and this works.