### PR TITLE
Fix for Pointer_stringify is not defined

### DIFF
--- a/Assets/StandaloneFileBrowser/Plugins/StandaloneFileBrowser.jslib
+++ b/Assets/StandaloneFileBrowser/Plugins/StandaloneFileBrowser.jslib
@@ -9,9 +9,9 @@ var StandaloneFileBrowserWebGLPlugin = {
     //     Custom: ".plist, .xml, .yaml"
     // multiselect: Allows multiple file selection
     UploadFile: function(gameObjectNamePtr, methodNamePtr, filterPtr, multiselect) {
-        gameObjectName = Pointer_stringify(gameObjectNamePtr);
-        methodName = Pointer_stringify(methodNamePtr);
-        filter = Pointer_stringify(filterPtr);
+        gameObjectName = UTF8ToString(gameObjectNamePtr);
+        methodName = UTF8ToString(methodNamePtr);
+        filter = UTF8ToString(filterPtr);
 
         // Delete if element exist
         var fileInput = document.getElementById(gameObjectName)
@@ -62,9 +62,9 @@ var StandaloneFileBrowserWebGLPlugin = {
     // byteArray: byte[]
     // byteArraySize: byte[].Length
     DownloadFile: function(gameObjectNamePtr, methodNamePtr, filenamePtr, byteArray, byteArraySize) {
-        gameObjectName = Pointer_stringify(gameObjectNamePtr);
-        methodName = Pointer_stringify(methodNamePtr);
-        filename = Pointer_stringify(filenamePtr);
+        gameObjectName = UTF8ToString(gameObjectNamePtr);
+        methodName = UTF8ToString(methodNamePtr);
+        filename = UTF8ToString(filenamePtr);
 
         var bytes = new Uint8Array(byteArraySize);
         for (var i = 0; i < byteArraySize; i++) {


### PR DESCRIPTION
Pointer_stringify was deprecated and removed from Unity somewhere around Unity 2021. This just updates it to UTF8ToString, which works fine.